### PR TITLE
Update default Slider min and max

### DIFF
--- a/src/fields/slider.js
+++ b/src/fields/slider.js
@@ -12,8 +12,11 @@ function Slider (name, initialValue, config, parentField) {
 
   Field.call(this, name, initialValue, parentField, config);
 
-  var min = config.min === undefined ? Math.min(initialValue, 0) : config.min;
-  var max = config.max === undefined ? Math.max(initialValue, 1) : config.max;
+  var isValueBetween0and1 = 0 <= initialValue && initialValue <= 1;
+  var defaultMin = isValueBetween0and1 ? 0 : Math.min(initialValue * 2, 0);
+  var defaultMax = isValueBetween0and1 ? 1 : Math.max(initialValue * 2, 1);
+  var min = config.min === undefined ? defaultMin : config.min;
+  var max = config.max === undefined ? defaultMax : config.max;
   var step = config.step === undefined ? 1 : config.step;
 
   this.type = 'slider';


### PR DESCRIPTION
when passing only a value to the Slider like `State.Slider(10)`, now:

- if the slider value is between 0 and 1, the max is 0 and the min is 1
- otherwise the max (min if it's negative) it's the double of the value

Closes #3   